### PR TITLE
Corrected Moran library model and function input consistency test

### DIFF
--- a/msi.gama.core/src/msi/gaml/operators/Spatial.java
+++ b/msi.gama.core/src/msi/gaml/operators/Spatial.java
@@ -7261,7 +7261,7 @@ public abstract class Spatial {
 			if (weightMatrix == null || weightMatrix.numCols != weightMatrix.numRows) throw GamaRuntimeException
 					.error("A squared weight matrix should be given for the moran index computation", scope);
 			final int N = vals.size();
-			if (N != weightMatrix.numRows * weightMatrix.numCols) throw GamaRuntimeException
+			if (N != weightMatrix.numRows) throw GamaRuntimeException
 					.error("The lengths of the value list and of the weight matrix do not match", scope);
 			double I = 0.0;
 			double sumWeights = 0.0;

--- a/msi.gama.models/models/Modeling/Spatial Topology/Spatial Operators/models/Moran Index.gaml
+++ b/msi.gama.models/models/Modeling/Spatial Topology/Spatial Operators/models/Moran Index.gaml
@@ -26,7 +26,7 @@ global {
 			}	
 		}
 		vals <- cell collect (each.color = #white ? 0.0 : 1.0);
-		weights <- 0.0 as_matrix {grid_size, grid_size};
+		weights <- 0.0 as_matrix {length(vals), length(vals)};
 		ask cell {
 			switch weight_type {
 				match "neighbors" {


### PR DESCRIPTION
There was a confusion in the library model between the weight matrix and the gaml grid.
The error in the consistency test was due to being tested on the library model.
Also added a neighbours spatial weight case. Fairly common with Moran index and easy to test.