### PR TITLE
fix: correct path fixing in debian-archive job

### DIFF
--- a/.github/workflows/github-travis.yml
+++ b/.github/workflows/github-travis.yml
@@ -299,8 +299,9 @@ jobs:
           sed -i "s/gama-platform-jdk$/gama-platform/g" ${{ github.workspace }}/${{ matrix.zipName }}/DEBIAN/control
           sed -i "s/Package: gama-platform$/Package: gama-platform-jdk/g" ${{ github.workspace }}/${{ matrix.zipName }}/DEBIAN/control
           sed -i "/^Depends:.*$/d" ${{ github.workspace }}/${{ matrix.zipName }}/DEBIAN/control
+
           # Pre-fix relative path for headless helper script (jdk path)
-          sed -i "s/\".*\.\/j/\/opt\/gama-platform\/j/g" ${{ github.workspace }}/${{ matrix.zipName }}/opt/gama-platform/headless/gama-headless.sh
+          sed -i "s|headless_path=.*|headless_path=/opt/gama-platform|g" ${{ github.workspace }}/${{ matrix.zipName }}/opt/gama-platform/headless/gama-headless.sh
 
       - name: Fix relative path for headless helper script (plugin path)
         run: sed -i "s/\".*\.\/p/\/opt\/gama-platform\/p/g" ${{ github.workspace }}/${{ matrix.zipName }}/opt/gama-platform/headless/gama-headless.sh

--- a/ummisco.gama.product/extraresources/headless/osx/gama-headless.sh
+++ b/ummisco.gama.product/extraresources/headless/osx/gama-headless.sh
@@ -47,11 +47,11 @@ function read_from_ini {
   tail -n +$start_line "$( dirname $( realpath "${BASH_SOURCE[0]}" ) )"/../Eclipse/Gama.ini | tr '\n' ' '
 }
 
-echo '******************************************************************'
-echo '* GAMA version 1.9.3                                             *'
-echo '* http://gama-platform.org                                       *'
-echo '* (c) 2007-2023 UMI 209 UMMISCO IRD/SU & Partners                *'
-echo '******************************************************************'
+echo "******************************************************************"
+echo "* GAMA version 1.9.3                                             *"
+echo "* http://gama-platform.org                                       *"
+echo "* (c) 2007-2023 UMI 209 UMMISCO IRD/SU & Partners                *"
+echo "******************************************************************"
 passWork=.workspace
 # w/ output folder
 if [ $workspaceCreate -eq 0 ]; then

--- a/ummisco.gama.product/extraresources/headless/unix/gama-headless.sh
+++ b/ummisco.gama.product/extraresources/headless/unix/gama-headless.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+headless_path=$( dirname $( realpath "${BASH_SOURCE[0]}" ) )
 java="java"
 
-if [ -d "$( dirname $( realpath "${BASH_SOURCE[0]}" ) )/../jdk" ]; then
-  java="$( dirname $( realpath "${BASH_SOURCE[0]}" ) )"/../jdk/bin/java
+if [ -d "${headless_path}/../jdk" ]; then
+  java="${headless_path}"/../jdk/bin/java
 else
   javaVersion=$(java -version 2>&1 | head -n 1 | cut -d "\"" -f 2)
   # Check if good Java version before everything
@@ -30,7 +31,7 @@ for arg do
 done
 
 if [[ $memory == "0" ]]; then
-  memory=$(grep Xmx "$( dirname $( realpath "${BASH_SOURCE[0]}" ) )"/../Gama.ini || echo "-Xmx4096m")
+  memory=$(grep Xmx "${headless_path}"/../Gama.ini || echo "-Xmx4096m")
 else
   memory=-Xmx$memory
 fi
@@ -44,15 +45,15 @@ esac
 
 
 function read_from_ini {
-  start_line=$(grep -n -- '-server' "$( dirname $( realpath "${BASH_SOURCE[0]}" ) )"/../Gama.ini | cut -d ':' -f 1)
-  tail -n +$start_line "$( dirname $( realpath "${BASH_SOURCE[0]}" ) )"/../Gama.ini | tr '\n' ' '
+  start_line=$(grep -n -- '-server' "${headless_path}"/../Gama.ini | cut -d ':' -f 1)
+  tail -n +$start_line "${headless_path}"/../Gama.ini | tr '\n' ' '
 }
 
-echo '******************************************************************'
-echo '* GAMA version 1.9.3                                             *'
-echo '* http://gama-platform.org                                       *'
-echo '* (c) 2007-2023 UMI 209 UMMISCO IRD/SU & Partners                *'
-echo '******************************************************************'
+echo "******************************************************************"
+echo "* GAMA version 1.9.3                                             *"
+echo "* http://gama-platform.org                                       *"
+echo "* (c) 2007-2023 UMI 209 UMMISCO IRD/SU & Partners                *"
+echo "******************************************************************"
 passWork=.workspace
 # w/ output folder
 if [ $workspaceCreate -eq 0 ]; then
@@ -72,7 +73,7 @@ fi
 
 ini_arguments=$(read_from_ini)
 
-if ! $java -cp "$( dirname $( realpath "${BASH_SOURCE[0]}" ) )"/../plugins/org.eclipse.equinox.launcher*.jar -Xms512m $memory ${ini_arguments[@]} org.eclipse.core.launcher.Main -configuration "$( dirname $( realpath "${BASH_SOURCE[0]}" ) )"/configuration -application msi.gama.headless.product -data $passWork "$@"; then
+if ! $java -cp "${headless_path}"/../plugins/org.eclipse.equinox.launcher*.jar -Xms512m $memory ${ini_arguments[@]} org.eclipse.core.launcher.Main -configuration "${headless_path}"/configuration -application msi.gama.headless.product -data $passWork "$@"; then
     echo "Error in you command, here's the log :"
     cat $passWork/.metadata/.log
     exit 1


### PR DESCRIPTION
This reverts commit 25bec5b77dc176e84f3ea63b6f061ef34405abeb.

The CI was failing not because of bad shell interpretation but because of a failed `sed` in line 304 of the GH workflow, that resulted in an unfinished string on line 5 of the headless script

```bash
# after downloading CI artifacts and installed the resulting gama-platform-jdk .deb file 
$ cat $(which gama-headless) 

...

if [ -d /opt/gama-platform/jdk" ]; then
```

I changed the sed command but also made the script DRY-esque so these errors cannot happen again :) 
