### PR TITLE
feat: add update date in release to trigger publish-to-third-party.yml

### DIFF
--- a/.github/workflows/publish-to-third-party.yml
+++ b/.github/workflows/publish-to-third-party.yml
@@ -5,6 +5,7 @@ on:
     # Triggers when a release was published, or a pre-release was changed to a release.
     # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=prereleased#release
     # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release
+    # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#release
     types: 
       - released
       - prereleased


### PR DESCRIPTION
It seems that the CI does not update the release but its [files instead](https://github.com/gama-platform/gama/blob/GAMA_1.9.3/travis/github_release_withjdk.sh#L209-L216) which does not trigger `publish-to-third-party.yml`

This PR updates the description of the pre-release in order to trigger said workflow