### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/msi.gama.ext/src/msi/gama/ext/osmosis/XmlConstants.java
+++ b/msi.gama.ext/src/msi/gama/ext/osmosis/XmlConstants.java
@@ -46,5 +46,5 @@ public final class XmlConstants {
 	/**
 	 * The default URL for the production API.
 	 */
-	public static final String DEFAULT_URL = "http://www.openstreetmap.org/api/0.6";
+	public static final String DEFAULT_URL = "https://api.openstreetmap.org/api/0.6";
 }


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)